### PR TITLE
Make job names shorter for tests

### DIFF
--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -147,7 +147,7 @@ async def test_job_list_filtered_by_status_and_name(helper: Helper) -> None:
     name_0 = None
     command = "sleep 10m"
     for i in range(N_JOBS):
-        name = f"my-job-{uuid4()}"
+        name = f"job-{uuid4().hex[:5]}"
         if not name_0:
             name_0 = name
         job = await helper.run_job(


### PR DESCRIPTION
The [tests](https://circleci.com/gh/neuromation/platform-e2e/57) fail because in some tests both job-name and job-owner are too long (see issue https://github.com/neuromation/platform-api/issues/607): 
```
'test-job-9f1acfde-7288-4637-b726-65aa2dffd872-shell-e2e-test-user-kz2lda8vctlstzarhrc9.jobs-dev.neu.ro'
```
Although, this PR does not fix all the problems: I could not find the place in `platform-e2e` where jobs are submitted with name `test-job-{uuid4()}` :(