### PR TITLE
New requirements for username max length fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Next ENV variables required:
 
 * CLIENT_TEST_E2E_ADMIN_TOKEN - admin token with `USERS_MANAGE` permission
 
-In this mode script will check if `neuromation-service-$CLUSTER_NAME` and `neuromation-test-$CLUSTER_NAME` users exist. If not then script will create these users self and then sue their tokens for tests.
+In this mode script will check if `neuro-{sha1(CLUSTER_NAME)[0:16]}-{1,2}` users exist. If not then script will create these users self and then use their tokens for tests.
 
 
 

--- a/cluster-test.sh
+++ b/cluster-test.sh
@@ -96,7 +96,8 @@ info "Cluster: $CLUSTER_NAME"
 if [ -z "$CLIENT_TEST_E2E_USER_NAME" ]
 then
     check_admin_token
-    USER_NAME="neuromation-service-$CLUSTER_NAME"
+    HASH=$(echo -n $CLUSTER_NAME | sha1sum)
+    USER_NAME="neuro-${HASH:0:16}-1"
     CLIENT_TEST_E2E_USER_NAME=$(user_token $USER_NAME $CLIENT_TEST_E2E_ADMIN_TOKEN)
     if [ -z "${CLIENT_TEST_E2E_USER_NAME}" ]
     then
@@ -111,7 +112,8 @@ fi
 if [ -z "$CLIENT_TEST_E2E_USER_NAME_ALT" ]
 then
     check_admin_token
-    USER_NAME="neuromation-test-$CLUSTER_NAME"
+    HASH=$(echo -n $CLUSTER_NAME | sha1sum)
+    USER_NAME="neuro-${HASH:0:16}-2"
     CLIENT_TEST_E2E_USER_NAME_ALT=$(user_token $USER_NAME $CLIENT_TEST_E2E_ADMIN_TOKEN)
     if [ -z "${CLIENT_TEST_E2E_USER_NAME_ALT}" ]
     then


### PR DESCRIPTION
Now platform require max length for usename 25 chars. This PR use hash from ClusterName for generating test usernames with 24 chars width, something like `neuro-e21cb3ef1fe380a9-1`

Tests will be red while #26 will be not merged