### PR TITLE
Drop flake8-isort, the functionality is replaced by isort pre-commit hook

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@ aiohttp==3.7.4.post0
 async_generator==1.10; python_version<"3.7"
 black==21.9b0
 flake8==4.0.1
-flake8-isort==4.1.1
 isort==5.9.3
 mypy==0.910
 pre-commit==2.15.0


### PR DESCRIPTION
Committed via https://github.com/asottile/all-repos