### PR TITLE
fix network isolation test

### DIFF
--- a/.github/workflows/setup-automerge.yml
+++ b/.github/workflows/setup-automerge.yml
@@ -1,6 +1,6 @@
 name: Enable auto-merge
 on:
-  pull_request_target:
+  pull_request:
     types: [opened]
 
 permissions:

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,16 +15,17 @@ include_package_data = True
 packages = find:
 platforms = any
 install_requires =
-    aiohttp==3.9.3
+    aiobotocore==2.12.0
     neuro-cli==24.2.0
     neuro-auth-client==22.6.1
     neuro-admin-client==23.5.0
-    yarl==1.9.4
+    yarl==1.8.2
     jose==1.0.0
     pytest==8.1.0
     pytest-dependency==0.5.1
     pytest-timeout==2.3.1
     pytest-aiohttp==1.0.5
+    pytest-asyncio==0.21.1
 
 [options.entry_points]
 pytest11 =

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -6,7 +6,6 @@ from typing import Any, AsyncIterator, Iterator
 from uuid import uuid4 as uuid
 
 import pytest
-import pytest_asyncio
 from neuro_sdk import JobStatus, RemoteImage, ResourceNotFound
 
 from platform_e2e import Helper, shell

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -32,7 +32,7 @@ def _build_image(image: RemoteImage) -> Iterator[None]:
     shell(f"docker rmi {image_url}")
 
 
-@pytest_asyncio.fixture(scope="session")
+@pytest.fixture(scope="session")
 async def image(helper: Helper) -> AsyncIterator[RemoteImage]:
     image = RemoteImage(
         name="platform-e2e",


### PR DESCRIPTION
Currently we create a single project and run all jobs in this project during tests. With the recent changes in job network policies jobs are allowed to access other jobs within the same project. This new rule breaks current network isolation test, we need to create jobs in different project for this test to pass.